### PR TITLE
IS-12 Requirements for Proxy-IdP:s

### DIFF
--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Deployment Profile for the Swedish eID Framework
 
-### Version 1.4 - 2017-02-13 
+### Version 1.4 - 2017-03-13 
 #### *Draft version*
 
 *ELN-0602-v1.4*
@@ -742,15 +742,27 @@ placed under the `<saml2:AuthnStatement>` element as the value of an
 
 ```
 <saml2:AuthnStatement AuthnInstant="2013-03-15T09:22:00" SessionIndex="b07b804c-7c29-ea16-7300-4f3d6f7928ac">
-  <saml2:AuthnContext>`
+  <saml2:AuthnContext>
     <saml2:AuthnContextClassRef>http://id.elegnamnden.se/loa/1.0/loa3</saml2:AuthnContextClassRef>
     ...
-  </saml2:AuthnContext>`
-</saml2:AuthnStatement>`
+  </saml2:AuthnContext>
+</saml2:AuthnStatement>
 ```
 
 *Example of how an Authentication Context URI identifier representing a
 Level of Assurance is included in an authentication statement.*
+
+An Identity Provider that acts as a proxy for other Identity Providers SHOULD include the `<saml2:AuthenticatingAuthority>` element under the `<saml2:AuthnContext>` element. This element will contain the entityID of the Identity Provider that was involved in authenticating the principal.
+
+```
+<saml2:AuthnStatement AuthnInstant="2013-03-15T09:22:00" SessionIndex="b07b804c-7c29-ea16-7300-4f3d6f7928ac">
+  <saml2:AuthnContext>
+    ...
+    <saml2:AuthenticatingAuthority>http://idp.company.com/auth</saml2:AuthenticatingAuthority>
+  </saml2:AuthnContext>
+</saml2:AuthnStatement>
+```
+*Example of how the entityID of an Identity Provider that provided the authentication for the principal is included in an authentication statement.*
 
 <a name="attribute-release-rules"></a>
 #### 6.2.1. Attribute Release Rules
@@ -1237,6 +1249,8 @@ response with the status code
     
 - A clarification to section 5.2 was made stating that conformant
   Identity Providers MUST support the HTTP-POST binding.
+  
+- Section 6.2 was updated with requirements for proxy-IdP:s that are expected to include the `<saml2:AuthenticatingAuthority>` element holding the entityID of the Identity Provider that provided the authentication of the principal.
 
 **Changes between version 1.2 and version 1.3:**
 

--- a/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
+++ b/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Attribute Specification for the Swedish eID Framework
 
-### Version 1.4 - 2017-02-13
+### Version 1.4 - 2017-03-13
 #### *Draft version*
 
 *ELN-0604-v1.4*
@@ -220,7 +220,7 @@ Framework.
 
 | Attribute requirement | Attributes |
 | :--- | :--- |
-| **REQUIRED**<sup>2</sup> | `prid` (Provisional ID) <br /> `pridPersistence` (Provisional ID persistence indicator) <br /> `eidasPersonIdentifier` (Mapping of the eIDAS PersonIdentifier attribute) <br /> `dateOfBirth` (Date of birth) <br /> `sn` (Surname) <br /> `givenName` (Given name) |
+| **REQUIRED**<sup>2</sup> | `prid` (Provisional ID) <br /> `pridPersistence` (Provisional ID persistence indicator) <br /> `eidasPersonIdentifier` (Mapping of the eIDAS PersonIdentifier attribute) <br /> `dateOfBirth` (Date of birth) <br /> `sn` (Surname) <br /> `givenName` (Given name) <br /> `transactionIdentifier` (ID of assertion issued by the member state node)<sup>4</sup> |
 | **REQUIRED**<br />(if available)<sup>3</sup> | `birthName` (Birth name) <br /> `placeOfBirth` (Place of birth) <br /> `eidasNaturalPersonAddress` (Address for natural person) <br /> `gender` (Gender) |
 | **RECOMMENDED** | `personalIdentityNumber` (National civic registration number) <br /> `personalIdentityNumberBinding` (National civic registration number Binding URI) |
 **Typical use**: In an attribute release policy implemented by an eIDAS
@@ -236,7 +236,7 @@ between eIDAS attributes and an Swedish identity number (see [section
 The eIDAS attribute set comprises of “added” and “converted” attributes.
 
 **Added attributes**: Attributes that are not provided by the member
-state node, but added by the\
+state node, but added by the
 Swedish eIDAS node in order to provide additional information about
 the authenticated subject obtained from relevant domestic attribute
 sources. The `prid`, `pridPersistence` and `personalIdentityNumber`
@@ -258,6 +258,8 @@ examples of “converted attributes”.
 > \[2\]: Attributes “added” by the Swedish eID node and converted attributes for the mandatory attributes of the eIDAS minimum data set for natural persons.
 
 > \[3\]: Converted attributes for the optional attributes of the eIDAS minimum data set for natural persons.
+
+> \[4\]: The transaction identifier attribute will contain the unique ID of the assertion that was issued by the member state node. This information together with the entityID of the member state node (found in the `<saml2:AuthenticatingAuthority>` element of an assertion) give a reference to the original assertion and authentication process.
 
 <a name="eidas-legal-person-attribute-set"></a>
 ### 2.6. eIDAS Legal Person Attribute Set


### PR DESCRIPTION
The eidas connector needs to include enough information in its
assertion so that the SP knows which IdP (member state node) that
provided the authentication and which assertion that was issued.