### PR TITLE
IS-13 Added cancel signature response status code

### DIFF
--- a/ELN-0603 - Registry for Identifiers.md
+++ b/ELN-0603 - Registry for Identifiers.md
@@ -2,7 +2,7 @@
 
 # Registry for identifiers assigned by the Swedish e-identification board
 
-### Version 1.4 - 2017-02-13
+### Version 1.4 - 2017-03-13
 #### *Draft version*
 
 *ELN-0603-v1.4*
@@ -310,10 +310,11 @@ for inclusion in a `<ResultMinor>` element of the `<Result>` element of a sign r
 
 | **URL** | **Object** | **Reference** |
 | :--- | :--- | :--- |
-| `http://id.elegnamnden.se/sig-status/1.0/req-expired` | The time window for the signature request has expired. | **\[OASIS-DSS\]** |
-| `http://id.elegnamnden.se/sig-status/1.0/user-mismatch` | The authenticated user does not match the signer identity attributes in the request. | **\[OASIS-DSS\]** |
-| `http://id.elegnamnden.se/sig-status/1.0/unsupported-loa` | The requested level of assurance for user authentication is not supported. | **\[OASIS-DSS\]** |
-| `http://id.elegnamnden.se/sig-status/1.0/sigmessage-error` | A requirement to display sign message was included in the sign request, but the sign service could not establish that the sign message was displayed to the user. | **\[OASIS-DSS\]** |
+| `http://id.elegnamnden.se/sig-status/1.0/req-expired` | The time window for the signature request has expired. | **\[CSignProf\]** |
+| `http://id.elegnamnden.se/sig-status/1.0/user-mismatch` | The authenticated user does not match the signer identity attributes in the request. | **\[CSignProf\]** |
+| `http://id.elegnamnden.se/sig-status/1.0/unsupported-loa` | The requested level of assurance for user authentication is not supported. | **\[CSignProf\]** |
+| `http://id.elegnamnden.se/sig-status/1.0/sigmessage-error` | A requirement to display sign message was included in the sign request, but the sign service could not establish that the sign message was displayed to the user. | **\[CSignProf\]** |
+| `http://id.elegnamnden.se/sig-status/1.0/user-cancel` | The end user cancelled the signature operation. | **\[CSignProf\]** |
 
 <a name="oid-identifiers"></a>
 ### 3.2. OID Identifiers
@@ -472,7 +473,7 @@ The following OIDs are defined in the ASN.1 declarations in [3.2.1](#asn1-declar
 
 -   The status code identifier
     `http://id.elegnamnden.se/sig-status/1.0/sigmessage-error` was added
-    to section 3.1.6.
+    to section 3.1.6 and the signature response status code `http://id.elegnamnden.se/sig-status/1.0/user-cancel` was added to section 3.1.7.
 
 **Changes between version 1.1 and version 1.2:**
 

--- a/ELN-0607 - Implementation Profile for using DSS in Central Signing Services.md
+++ b/ELN-0607 - Implementation Profile for using DSS in Central Signing Services.md
@@ -2,9 +2,10 @@
 
 #  Implementation Profile for using OASIS DSS in Central Signing Services
 
-### Version 1.1 - 2015-10-05
+### Version 1.2 - 2017-03-13
+#### *Draft version*
 
-*ELN-0607-v1.1*
+*ELN-0607-v1.2*
 
 ---
 
@@ -466,7 +467,7 @@ the `<dss:ResultMajor>` value
 signature creation.
 
 With the exception above, the response values defined in section 2.6 of
-the DSS standard, amended by status identifiers defined in section 3.1.5
+the DSS standard, amended by status identifiers defined in section 3.1.7
 of \[[Eid-Registry](#eid-registry)\], SHOULD be used.
 
 <a name="generated-signature"></a>
@@ -691,9 +692,12 @@ EidSignResponse | Base64 encoded sign response.
 <a name="saml2bind"></a>**[SAML2Bind]**
 > [OASIS Standard, Bindings for the OASIS Security Assertion Markup Language (SAML) V2.0, March 2005.](http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf)
 
-
 <a name="changes-between-versions"></a>
 ## 5. Changes between versions
+
+**Changes between version 1.1 and version 1.2:**
+
+- In section 2.2.2, a reference to section 3.1.5 in \[Eid-Registry\] was changed to section 3.1.7.
 
 **Changes between version 1.0 and version 1.1:**
 

--- a/versions.md
+++ b/versions.md
@@ -9,7 +9,7 @@
 | [ELN-0604 - Attribute Specification for the Swedish eID Framework](ELN-0604%20-%20Attribute%20Specification%20for%20the%20Swedish%20eID%20Framework.md) | 1.4 (draft) |
 | ~~ELN-0605 - Authentication Context Classes for Levels of Assurance for the Swedish eID Framework~~ (deprecated) | ~~1.1~~ |
 | [ELN-0606 - Entity Categories for the Swedish eID Framework](ELN-0606%20-%20Entity%20Categories%20for%20the%20Swedish%20eID%20Framework.md) | 1.5 (draft) |
-| [ELN-0607 - Implementation Profile for using DSS in Central Signing Services](ELN-0607%20-%20Implementation%20Profile%20for%20using%20DSS%20in%20Central%20Signing%20Services.md) | 1.1 |
+| [ELN-0607 - Implementation Profile for using DSS in Central Signing Services](ELN-0607%20-%20Implementation%20Profile%20for%20using%20DSS%20in%20Central%20Signing%20Services.md) | 1.2 (draft) |
 | [ELN-0608 - Certificate Profile for Central Signing Services](ELN-0608%20-%20Certificate%20Profile%20for%20Central%20Signing%20Services.md) | 1.0 |
 | [ELN-0609 - DSS Extension for Federated Signing Services](ELN-0609%20-%20DSS%20Extension%20for%20Federated%20Signing%20Services.md) | 1.1 |
 | ~~ELN-0610 - Discovery within the Swedish eID Framework~~ | ~~1.1~~ |


### PR DESCRIPTION
The status code http://id.elegnamnden.se/sig-status/1.0/user-cancel was
added. It is used to signal that a user has cancelled the
“authentication for signature”-process.