### PR TITLE
Feature/is 23 provided id in requests

### DIFF
--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -522,6 +522,8 @@ Service Providers SHOULD include the `ForceAuthn` attribute in all
 `true` or `false`, and not rely on its default value. The reason for this is
 to avoid accidental SSO.
 
+A Service Provider MAY include a `<saml2:Subject>` element containing an identity in the `SPProvidedID` attribute. This identifier may be useful for some Identity Providers in the process of authenticating the user. For example, the Service Provider may supply an identifier that is the user's identity at the Identity Provider. This identifier may have been received as an attribute in a previous interaction with the Identity Provider. Other profiles within the Swedish eID Framework may further state more specific requirements about the use of the `SPProvided` attribute.
+
 > \[1\]: See section 3.1.1 of \[EidRegistry\].
 
 <a name="processing-requirements"></a>
@@ -1029,6 +1031,14 @@ It is RECOMMENDED that the `<saml2p:Scoping>` element containing a `<saml2p:Requ
 *Example when the `<saml2p:RequesterID>` element is used to inform the Identity Provider about which Service Provider that requested the signature associated with this request for authentication.*
 
 > The reason for this recommendation is that an Identity Provider may adapt user interfaces or authentication procedures to different Service Providers based on either static configuration or on information found in the Service Provider's metadata. It can therefore be useful for an Identity Provider to know which Service Provider that requested the signature (*Signature Requestor*) that caused a Signature Service to request authentication. The Identity Provider may use this information to maintain the same user experience and procedures regardless of whether authentication is requested directly by the Service Provider, or by a Signature Service as a result of a signature request from the same Service Provider.
+
+If the Signature Requestor has authenticated the user at the Identity Provider within the same session as the request for signature is executed, it is RECOMMENDED that the Signature Service, in the `<saml2p:AuthnRequest>` message, includes a `<saml2:Subject>` element with a `SPProvidedID` attribute holding the user identifier from the this authentication. This user identifier is the identity that the authenticated user has at the Identity Provider. If the Service Provider does not know about the type of identities used by the Identity Provider, or if this information was not part of the attribute release from the authentication, the Service Provider MUST NOT include a `SPProvidedID` attribute.
+
+The value from the `SPProvidedID` attribute MAY be used by an Identity Provider processing an authentication for signature request in different ways. As an example, the Identity Provider may be able to avoid prompting the user for his or hers identity if this was passed in the `<saml2p:AuthnRequest>` message.
+
+    <saml2:Subject SPProvidedID="196911212032" />
+
+*Example of how the value of a personal identity number attribute (`personalIdentityNumber`) is passed in a authentication request in order to supply the Identity Provider with a possible hint for its processing.*
 
 An Identity Provider that accepts an `<saml2p:AuthnRequest>` message
 from a Service Provider that has indicated that it is a Signature

--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -2,9 +2,11 @@
 
 # Deployment Profile for the Swedish eID Framework
 
-### Version 1.5 - 2017-06-05 - *draft version*
+### Version 1.5 - 2017-06-08 - *draft version*
 
 *ELN-0602-v1.5*
+
+[Latest official version - 1.4](http://elegnamnden.github.io/technical-framework/latest/ELN-0602_-_Deployment_Profile_for_the_Swedish_eID_Framework.html)
 
 ---
 
@@ -522,7 +524,15 @@ Service Providers SHOULD include the `ForceAuthn` attribute in all
 `true` or `false`, and not rely on its default value. The reason for this is
 to avoid accidental SSO.
 
-A Service Provider MAY include a `<saml2:Subject>` element containing an identity in the `SPProvidedID` attribute. This identifier may be useful for some Identity Providers in the process of authenticating the user. For example, the Service Provider may supply an identifier that is the user's identity at the Identity Provider. This identifier may have been received as an attribute in a previous interaction with the Identity Provider. Other profiles within the Swedish eID Framework may further state more specific requirements about the use of the `SPProvided` attribute.
+A Service Provider MAY include a `<saml2:Subject>` element with a `<saml2:NameID>` containing the identity that the user has at the Identity Provider in the `SPProvidedID` attribute. The value from the `SPProvidedID` attribute MAY be used by an Identity Provider processing an authentication request. As an example, the Identity Provider may be able to avoid prompting the user for his or hers identity if this information was passed in the `<saml2p:AuthnRequest>` message.
+
+The Service Provider may acquire this user identity in various ways, for example, it may have received the identity in an attribute from a previous interaction with the Identity Provider (see [section 7.2](#authentication-requests2)), by prompting the user, or any other way. If the Service Provider does not know about the type of user identities that the Identity Provider uses, or if this information is not available, the Service Provider MUST NOT include a `SPProvidedID` attribute.
+
+    <saml2:Subject>
+      <saml2:NameID SPProvidedID="196911212032" />
+    </saml2:Subject> 
+
+*Example of how the value of a personal identity number attribute (`personalIdentityNumber`) is passed in a authentication request in order to supply the Identity Provider with extra information for its processing.* 
 
 > \[1\]: See section 3.1.1 of \[EidRegistry\].
 
@@ -1032,13 +1042,9 @@ It is RECOMMENDED that the `<saml2p:Scoping>` element containing a `<saml2p:Requ
 
 > The reason for this recommendation is that an Identity Provider may adapt user interfaces or authentication procedures to different Service Providers based on either static configuration or on information found in the Service Provider's metadata. It can therefore be useful for an Identity Provider to know which Service Provider that requested the signature (*Signature Requestor*) that caused a Signature Service to request authentication. The Identity Provider may use this information to maintain the same user experience and procedures regardless of whether authentication is requested directly by the Service Provider, or by a Signature Service as a result of a signature request from the same Service Provider.
 
-If the Signature Requestor has authenticated the user at the Identity Provider within the same session as the request for signature is executed, it is RECOMMENDED that the Signature Service, in the `<saml2p:AuthnRequest>` message, includes a `<saml2:Subject>` element with a `SPProvidedID` attribute holding the user identifier from the this authentication. This user identifier is the identity that the authenticated user has at the Identity Provider. If the Service Provider does not know about the type of identities used by the Identity Provider, or if this information was not part of the attribute release from the authentication, the Service Provider MUST NOT include a `SPProvidedID` attribute.
+If the Signature Requestor has authenticated the user at the Identity Provider within the same session as the request for signature is executed, it is RECOMMENDED that the Signature Service, in the `<saml2p:AuthnRequest>` message, includes a `<saml2:Subject>` element with a `<saml2:NameID>` element containing a `SPProvidedID` attribute holding the user identifier from this authentication. This is further described in [section 5.3](#message-content).
 
-The value from the `SPProvidedID` attribute MAY be used by an Identity Provider processing an authentication for signature request in different ways. As an example, the Identity Provider may be able to avoid prompting the user for his or hers identity if this was passed in the `<saml2p:AuthnRequest>` message.
-
-    <saml2:Subject SPProvidedID="196911212032" />
-
-*Example of how the value of a personal identity number attribute (`personalIdentityNumber`) is passed in a authentication request in order to supply the Identity Provider with a possible hint for its processing.*
+> The reason for this recommendation is that the user probably already has given his or hers user identity when authenticating at the Identity Provider, and for a better user experience it is therefore desirable to avoid prompting for the same information again.
 
 An Identity Provider that accepts an `<saml2p:AuthnRequest>` message
 from a Service Provider that has indicated that it is a Signature
@@ -1235,6 +1241,7 @@ response with the status code
 **Changes between version 1.4 and 1.5:**
 
 - Section 7.2, "Authentication Requests", was extended to recommend the usage of the `<saml2p:RequesterID>` element within `<saml2p:Scoping>`. The reason for this recommendation is that Identity Providers may need information about the "Signature Requestor", i.e., the Service Provider that requested the signature that caused a Signature Service to request authentication.
+- In section 5.3, "Message Content", information was added about how a Service Provider may use the `SPProvidedID` attribute within a `<saml2:Subject>` element that is included in the authentication request in order to supply to the Identity Provider information about the user that is about to be authenticated. Section 7.2, "Authentication Requests", further describes how an authentication request issued by a Signature Service should make use of the `SPProvidedID` attribute.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/ELN-0612 - BankID Profile for the Swedish eID Framework.md
+++ b/ELN-0612 - BankID Profile for the Swedish eID Framework.md
@@ -2,9 +2,11 @@
 
 # Implementation Profile for BankID Identity Providers within the Swedish eID Framework
 
-### Version 1.0 - 2017-03-28
+### Version 1.1 - 2017-06-08 - *draft version*
 
-*ELN-0612-v1.0*
+*ELN-0612-v1.1*
+
+[Latest official version - 1.0](http://elegnamnden.github.io/technical-framework/latest/ELN-0612_-_BankID_Profile_for_the_Swedish_eID_Framework.html)
 
 ---
 
@@ -51,6 +53,8 @@
     4.2.1.2. [userNonVisibleData](#usernonvisibledata)
 
     4.2.2. [Mobile BankID and the personNumber attribute](#mobile-bankid-and-the-personnumber-attribute)
+    
+    4.3. [General Processing](#general-processing)
 
 5. [**Authentication Responses**](#authentication-responses)
 
@@ -67,6 +71,8 @@
     6.3. [Signature Services](#signature-services)
 
 7. [**References**](#references)
+
+8. [**Changes between versions**](#changes-between-versions)
 
 ---
 
@@ -230,9 +236,11 @@ Auto starting the BankID app from a mobile device requires the built-in web brow
 <a name="prompting-for-personal-identity-number"></a>
 ### 3.3. Prompting for Personal Identity Number (personnummer)
 
-When the user agent (web browser) and the BankID client (app or desktop) is not on the same device the Identity Provider prompts the user for his or hers personal identity number (personnummer) in order to initiate an BankID authentication. It is RECOMMENDED that the personal identity number is saved in the user's web browser session storage (in a session cookie or more preferably using the HTML5 sessionStorage object). The reason for this is that if the user performs a signature operation after authenticating he or she does not expect to have to enter the personal identity number again.
+When the user agent (web browser) and the BankID client (app or desktop) is not on the same device the Identity Provider prompts the user<sup>1</sup> for his or hers personal identity number (personnummer) in order to initiate an BankID authentication. It is RECOMMENDED that the personal identity number is saved in the user's web browser session storage (in a session cookie or more preferably using the HTML5 sessionStorage object). The reason for this is that if the user performs a signature operation after authenticating he or she does not expect to have to enter the personal identity number again.
 
 See also section [4.2.2](#mobile-bankid-and-the-personnumber-attribute), "[Mobile BankID and the personNumber attribute](#mobile-bankid-and-the-personnumber-attribute)".
+
+> \[1\]: Unless the personal identity number is included in the authentication request, see sections [4.2.2](#mobile-bankid-and-the-personnumber-attribute) and [4.3](#general-processing) below.
 
 <a name="cancelling-an-operation"></a>
 ### 3.4. Cancelling an Operation
@@ -291,9 +299,20 @@ It is RECOMMENDED that the following function is used to produce this unique bin
 <a name="mobile-bankid-and-the-personnumber-attribute"></a>
 #### 4.2.2. Mobile BankID and the personNumber attribute
 
-When Mobile BankID is being used to sign data and the user has initiated the signature operation against the Signature Service from another device (desktop och tablet) the `personNumber` parameter must be assigned in the BankID `Sign`-call. This information is not passed in the `<saml2p:AuthnRequest>` message sent from the Signature Service. In these cases the Identity Provider SHOULD rely on the fact that the user, most likely<sup>1</sup>, already has been authenticated at the Identity Provider, and use the personal identity number given when the user authenticated also for the signature operation (see section [3.3](#prompting-for-personal-identity-number), "[Prompting for Personal Identity Number (personnummer)](#prompting-for-personal-identity-number)", above). Only in cases when the Identity Provider can not obtain the personal identity number should a dialogue asking the personal identity number be displayed.
+When Mobile BankID is being used to sign data and the user has initiated the signature operation against the Signature Service from another device (desktop och tablet) the `personNumber` parameter must be assigned in the BankID `Sign`-call. 
 
-> \[1\]: Almost all use cases where a user signs data is preceded by a login (authentication).
+This personal identity number may be available in the `<saml2p:AuthnRequest>` message since a Signature Service is recommended to include a `<saml2:Subject>` element that has a `<saml2:NameID>` element with the attribute `SPProvidedID` attribute holding the identity that the user has at the Identity Provider<sup>1</sup>. In the BankID case this is the personal identity number. A BankID Identity Provider SHOULD support processing of this attribute, and MUST validate it to be a valid personal identity number before using it. 
+
+In cases where the personal identity number can be found in a `<saml2p:AuthnRequest>` message as described above, it should be used as the `personNumber` parameter that is passed in the BankID `Sign`-call. If this information is not available in the request, the Identity Provider SHOULD rely on the fact that the user, most likely<sup>2</sup>, already has been authenticated at the Identity Provider, and use the personal identity number given when the user authenticated also for the signature operation (see section [3.3](#prompting-for-personal-identity-number), "[Prompting for Personal Identity Number (personnummer)](#prompting-for-personal-identity-number)", above). Only in cases when the Identity Provider can not obtain the personal identity number should a dialogue asking the personal identity number be displayed.
+
+> \[1\]: See section 7.2 of \[[EidProfile](#eid-profile)\].
+> 
+> \[2\]: Almost all use cases where a user signs data is preceded by a login (authentication).
+
+<a name="general-processing"></a>
+### 4.3. General Processing
+
+Section 5.3 of \[[EidProfile](#eid-profile)\] describes how a Service Provider MAY pass the user's identity (personal identity number) in a `<saml2p:AuthnRequest>` message by including a `<saml2:Subject>` element that has a `<saml2:NameID>` element with the attribute `SPProvidedID` attribute holding the identity. [Section 4.2.2](#mobile-bankid-and-the-personnumber-attribute) above, states that an Identity Provider for Mobile BankID that processes a "authentication for signature" request SHOULD support this attribute. For other cases it is OPTIONAL for a BankID Identity Provider to process the attribute, but it should be pointed out that the user experience may be improved since the Identity Provider does not have to prompt the user for his or hers personal identity number (see section [3.3](#prompting-for-personal-identity-number), "[Prompting for Personal Identity Number (personnummer)](#prompting-for-personal-identity-number)", above).
 
 <a name="authentication-responses"></a>
 ## 5. Authentication Responses
@@ -404,15 +423,22 @@ It is RECOMMENDED that a Signature Service explicitly requires release of the `u
 
 <a name="bankid-spec"></a>
 **\[BankID_Spec\]**
-> [BankID Relying Party Guidelines, version 2.13](https://www.bankid.com/assets/bankid/rp/bankid-relying-party-guidelines-v2.13.pdf).
+> [BankID Relying Party Guidelines, version 2.15](https://www.bankid.com/assets/bankid/rp/bankid-relying-party-guidelines-v2.15.pdf).
 > 
 > *Check [www.bankid.com/rp/info](https://www.bankid.com/rp/info) for lastest version.*
 
 <a name="eid-profile"></a>
 **\[EidProfile\]**
-> [Deployment Profile for the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0602_-_Deployment_Profile_for_the_Swedish_eID_Framework.html).
+> [Deployment Profile for the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/draft/ELN-0602_-_Deployment_Profile_for_the_Swedish_eID_Framework.html).
 
 <a name="eid-attributes"></a>
 **\[EidAttributes\]**
 > [Attribute Specification for the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0604_-_Attribute_Specification_for_the_Swedish_eID_Framework.html).
+
+<a name="changes-between-versions"></a>
+## 8. Changes between versions
+
+**Changes between version 1.0 and 1.1:**
+
+- Section 4.2.2, "Mobile BankID and the personNumber attribute", was updated to recommend the Identity Provider to try to obtain the user's personal identity number from the `SPProvidedID` found in the `<saml2:NameID>` element under the `<saml2:Subject>` element. Also, section 4.3, "General Processing", was added where the use of the `SPProvidedID` attribute was further discussed.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Implementation profile for Identity Providers implementing BankID support.
 
 ### Updates to the current version of the specifications
 
-> [Updates to the Swedish eID Framework](Updates%20to%20the%20Swedish%20eID%20Framework.md) - 2017-05-24
+> [Updates to the Swedish eID Framework](Updates%20to%20the%20Swedish%20eID%20Framework.md) - 2017-06-08
 
 ## Older versions
 

--- a/Updates to the Swedish eID Framework.md
+++ b/Updates to the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Updates to the Swedish eID Framework
 
-### 2017-05-24
+### 2017-06-08
 
 ## Table of Contents
 
@@ -12,7 +12,9 @@
 
 2. [Updates](#updates)
 
-  E.1 [Scoping in Authentication Requests sent by Signature Services](#e1)
+  E.1. [Scoping in Authentication Requests sent by Signature Services](#e1)
+
+  E.2. [Including a User Identity in an Authentication Request](#e2) 
 
 <a name="Introduction"></a>
 ## 1. Introduction
@@ -46,6 +48,9 @@ New specification text is typically presented as follows, with new or changed te
 **\[EidProfile\]**
 > [Deployment Profile for the Swedish eID Framework, version 1.4](http://elegnamnden.github.io/technical-framework/latest/ELN-0602_-_Deployment_Profile_for_the_Swedish_eID_Framework.html)
 
+**\[BankIDProfile\]**
+> [Implementation Profile for BankID Identity Providers within the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0612_-_BankID_Profile_for_the_Swedish_eID_Framework.html)
+
 <a name="updates"></a>
 ## 2. Updates
 
@@ -66,4 +71,48 @@ An Identity Provider may adapt user interfaces or authentication procedures to d
 
 ***Example when the `<saml2p:RequesterID>` element is used to inform the Identity Provider about which Service Provider that requested the signature associated with this request for authentication.***
 
+<a name="e2"></a>
+### E.2. Including a User Identity in an Authentication Request
+
+**Updates**: Version 1.4 of the “[Deployment Profile for the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0602_-_Deployment_Profile_for_the_Swedish_eID_Framework.html)” and version 1.0 of the "[Implementation Profile for BankID Identity Providers within the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0612_-_BankID_Profile_for_the_Swedish_eID_Framework.html)".
+
+There are cases, especially when a Signature Service sends an authentication request, where the user experience would be greatly improved and the Identity Provider processing would become easier, if an authentication request message would include information about the user identity (if known to the Service Provider). Therefore, the following changes have been made.
+
+#### Section 5.3 of  \[EidProfile\]
+
+**New:**
+
+**A Service Provider MAY include a `<saml2:Subject>` element with a `<saml2:NameID>` containing the identity that the user has at the Identity Provider in the `SPProvidedID` attribute. The value from the `SPProvidedID` attribute MAY be used by an Identity Provider processing an authentication request. As an example, the Identity Provider may be able to avoid prompting the user for his or hers identity if this information was passed in the `<saml2p:AuthnRequest>` message.**
+
+**The Service Provider may acquire this user identity in various ways, for example, it may have received the identity in an attribute from a previous interaction with the Identity Provider (see section 7.2), by prompting the user, or any other way. If the Service Provider does not know about the type of user identities that the Identity Provider uses, or if this information is not available, the Service Provider MUST NOT include a `SPProvidedID` attribute.**
+
+    <saml2:Subject>
+      <saml2:NameID SPProvidedID="196911212032" />
+    </saml2:Subject> 
+
+***Example of how the value of a personal identity number attribute (`personalIdentityNumber`) is passed in a authentication request in order to supply the Identity Provider with extra information for its processing.***
+
+#### Section 7.2 of  \[EidProfile\]
+
+**New:**
+
+**If the Signature Requestor has authenticated the user at the Identity Provider within the same session as the request for signature is executed, it is RECOMMENDED that the Signature Service, in the `<saml2p:AuthnRequest>` message, includes a `<saml2:Subject>` element with a `<saml2:NameID>` element containing a `SPProvidedID` attribute holding the user identifier from this authentication. This is further described in section 5.3.**
+
+**The reason for this recommendation is that the user probably already has given his or hers user identity when authenticating at the Identity Provider, and for a better user experience it is therefore desirable to avoid prompting for the same information again.**
+
+#### Section 4.2.2. of  \[BankIDProfile\]
+
+**Original:**
+
+When Mobile BankID is being used to sign data and the user has initiated the signature operation against the Signature Service from another device (desktop och tablet) the personNumber parameter must be assigned in the BankID Sign-call. 
+
+**This information is not passed in the `<saml2p:AuthnRequest>` message sent from the Signature Service. In these cases** the Identity Provider SHOULD rely on the fact that the user, most likely, already has been authenticated at the Identity Provider, and use the personal identity number given when the user authenticated also for the signature operation (see section 3.3, "Prompting for Personal Identity Number (personnummer)", above). Only in cases when the Identity Provider can not obtain the personal identity number should a dialogue asking the personal identity number be displayed.
+
+**New:**
+
+When Mobile BankID is being used to sign data and the user has initiated the signature operation against the Signature Service from another device (desktop och tablet) the `personNumber` parameter must be assigned in the BankID `Sign`-call. 
+
+**This personal identity number may be available in the `<saml2p:AuthnRequest>` message since a Signature Service is recommended to include a `<saml2:Subject>` element that has a `<saml2:NameID>` element with the attribute `SPProvidedID` attribute holding the identity that the user has at the Identity Provider. In the BankID case this is the personal identity number. A BankID Identity Provider SHOULD support processing of this attribute, and MUST validate it to be a valid personal identity number before using it.** 
+
+**In cases where the personal identity number can be found in a `<saml2p:AuthnRequest>` message as described above, it should be used as the `personNumber` parameter that is passed in the BankID `Sign`-call. If this information is not available in the requests** the Identity Provider SHOULD rely on the fact that the user, most likely, already has been authenticated at the Identity Provider, and use the personal identity number given when the user authenticated also for the signature operation (see section 3.3, "Prompting for Personal Identity Number (personnummer)", above). Only in cases when the Identity Provider can not obtain the personal identity number should a dialogue asking the personal identity number be displayed.
 

--- a/versions.md
+++ b/versions.md
@@ -14,12 +14,13 @@
 | [ELN-0609 - DSS Extension for Federated Signing Services](ELN-0609%20-%20DSS%20Extension%20for%20Federated%20Signing%20Services.md) | 1.1 |
 | ~~ELN-0610 - Discovery within the Swedish eID Framework~~ | ~~1.1~~ |
 | [ELN-0611 - eIDAS Attribute Mapping Specification for the Swedish eID Framework](ELN-0611%20-%20eIDAS%20Constructed%20Attributes%20Specification%20for%20the%20Swedish%20eID%20Framework.md) | 1.0 |
-| [ELN-0612 - BankID Profile for the Swedish eID Framework](ELN-0612%20-%20BankID%20Profile%20for%20the%20Swedish%20eID%20Framework.md) | 1.0 |
+| [ELN-0612 - BankID Profile for the Swedish eID Framework](ELN-0612%20-%20BankID%20Profile%20for%20the%20Swedish%20eID%20Framework.md) | 1.1 (draft) |
 
 ### Current version of update document
 
-The document "[Updates to the Swedish eID Framework](Updates%20to%20the%20Swedish%20eID%20Framework.md)" was updated 2017-05-24.
+The document "[Updates to the Swedish eID Framework](Updates%20to%20the%20Swedish%20eID%20Framework.md)" was updated 2017-06-08.
 
 It comprises changes added to the following draft versions:
 
 - [ELN-0602 - Deployment Profile for the Swedish eID Framework](ELN-0602%20-%20Deployment%20Profile%20for%20the%20Swedish%20eID%20Framework.md) - 1.5 (draft)
+- [ELN-0612 - BankID Profile for the Swedish eID Framework](ELN-0612%20-%20BankID%20Profile%20for%20the%20Swedish%20eID%20Framework.md) - 1.1 (draft)


### PR DESCRIPTION
Added recommendations for using the SPProvidedID attribute that is an attribute of the NameID element placed under the Subject element in an AuthnRequest.

By this we aim to supply the user identity to the Identity Provider so that it does not have to prompt for this. Which is not want we want in "authentication for signature" cases.