### PR TITLE
IS-47 Added requirements for dateOfBirth attribute

### DIFF
--- a/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
+++ b/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Attribute Specification for the Swedish eID Framework
 
-### Version 1.5 - 2018-01-02 - *draft version*
+### Version 1.5 - 2018-03-18 - *draft version*
 
 *ELN-0604-v1.5*
 
@@ -187,6 +187,7 @@ The “Personal Identity with Civic Registration Number” attribute set provide
 | Attribute requirement | Attributes |
 | :--- | :--- |
 | **REQUIRED** | `sn` (Surname) <br /> `givenName` (Given name) <br /> `displayName` (Display name) <br /> `personalIdentityNumber` (National civic registration number) |
+| **RECOMMENDED** | `dateOfBirth` (Date of birth) |
 
 **Typical use**: In an attribute release policy that provides basic user name information together with the person’s Swedish civic registration number.
 
@@ -219,8 +220,8 @@ Framework.
 
 | Attribute requirement | Attributes |
 | :--- | :--- |
-| **REQUIRED**<sup>2</sup> | `prid` (Provisional ID) <br /> `pridPersistence` (Provisional ID persistence indicator) <br /> `eidasPersonIdentifier` (Mapping of the eIDAS PersonIdentifier attribute) <br /> `dateOfBirth` (Date of birth) <br /> `sn` (Surname) <br /> `givenName` (Given name) <br /> `transactionIdentifier` (ID of assertion issued by the member state node)<sup>4</sup> |
-| **REQUIRED**<br />(if available)<sup>3</sup> | `birthName` (Birth name) <br /> `placeOfBirth` (Place of birth) <br /> `eidasNaturalPersonAddress` (Address for natural person) <br /> `gender` (Gender) |
+| **REQUIRED**<sup>2</sup> | `prid` (Provisional ID) <br /> `pridPersistence` (Provisional ID persistence indicator) <br /> `eidasPersonIdentifier` (Mapping of the eIDAS PersonIdentifier attribute) <br /> `dateOfBirth` (Date of birth) <br /> `sn` (Surname) <br /> `givenName` (Given name) <br /> `transactionIdentifier` (ID of assertion issued by the member state node)<sup>3</sup> |
+| **REQUIRED**<br />(if available)<sup>4</sup> | `birthName` (Birth name) <br /> `placeOfBirth` (Place of birth) <br /> `eidasNaturalPersonAddress` (Address for natural person) <br /> `gender` (Gender) |
 | **RECOMMENDED** | `personalIdentityNumber` (National civic registration number) <br /> `personalIdentityNumberBinding` (National civic registration number Binding URI) |
 **Typical use**: In an attribute release policy implemented by an eIDAS
 connector that provides a complete set of attributes to a requesting
@@ -256,9 +257,9 @@ examples of “converted attributes”.
 
 > \[2\]: Attributes “added” by the Swedish eID node and converted attributes for the mandatory attributes of the eIDAS minimum data set for natural persons.
 
-> \[3\]: Converted attributes for the optional attributes of the eIDAS minimum data set for natural persons.
+> \[3\]: The transaction identifier attribute will contain the unique ID of the assertion that was issued by the member state node. This information together with the entityID of the member state node (found in the `<saml2:AuthenticatingAuthority>` element of an assertion) give a reference to the original assertion and authentication process.
 
-> \[4\]: The transaction identifier attribute will contain the unique ID of the assertion that was issued by the member state node. This information together with the entityID of the member state node (found in the `<saml2:AuthenticatingAuthority>` element of an assertion) give a reference to the original assertion and authentication process.
+> \[4\]: Converted attributes for the optional attributes of the eIDAS minimum data set for natural persons.
 
 <a name="eidas-legal-person-attribute-set"></a>
 ### 2.6. eIDAS Legal Person Attribute Set
@@ -613,6 +614,7 @@ following attribute:
 
 - Section 3.2.3 was updated with a reference to the SAP specification as source for defining the content of the `sad` attribute.
 - Fix of invalid links for SKV704 and SKV707.
+- Section 2.3, "Natural Personal Identity with Civic Registration Number (Personnummer)", was updated so that the `dateOfBirth`-attribute is listed as a recommended attribute for the attribute set `http://id.elegnamnden.se/ap/1.0/pnr-01`.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
+++ b/ELN-0604 - Attribute Specification for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Attribute Specification for the Swedish eID Framework
 
-### Version 1.5 - 2018-03-18 - *draft version*
+### Version 1.5 - 2018-03-26 - *draft version*
 
 *ELN-0604-v1.5*
 

--- a/ELN-0606 - Entity Categories for the Swedish eID Framework.md
+++ b/ELN-0606 - Entity Categories for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Entity Categories for the Swedish eID Framework
 
-### Version 1.6 - 2017-12-18 - *draft version*
+### Version 1.6 - 2018-03-18 - *draft version*
 
 *ELN-0606-v1.6*
 
@@ -295,13 +295,20 @@ have an agreement with the Identity Provider.
 
 **Description**: For asserting a Swedish identity to a foreign service provider via the Swedish eIDAS Proxy Service. This entity category MUST NOT be set by any entity other than Identity Provider providing identity assertions to the Swedish eIDAS Proxy Service and by the Swedish eIDAS Proxy Service itself.
 
-Note that the Identity Providers release attributes according to the "Natural Personal Identity with Civic Registration Number" attribute set. It is the responsibility of the Swedish eIDAS Proxy Service to transform these attributes into eIDAS attributes.
+The attribute release is according to the "Natural Personal Identity with Civic Registration Number" attribute set with the addition of the `dateOfBirth`-attribute (`urn:oid:1.3.6.1.5.5.7.9.1`). The reason that the `dateOfBirth`-attribute is required is that the eIDAS minimum dataset requires the birth date, and if an Identity Provider releases a "samordningsnummer" in the `personalIdentityNumber` (instead of a Swedish "personnummer"), the birth date may not be known to the attribute consumer.
+
+It is the responsibility of the Swedish eIDAS Proxy Service to transform these attributes into eIDAS attributes.
 
 **LoA-identifier**: Not applicable
 > An Identity Provider delivering assertions to the eIDAS framework is obliged to announce which levels that it supports by including the corresponding eIDAS authentication context URIs defined in section 3.1.1 of \[EidRegistry\] as assurance certification attributes in its metadata as described in section 2.1.3 of \[EidDeploy\].
 
-**Attribute requirements**: ELN-AP-Pnr-01 (`http://id.elegnamnden.se/ap/1.0/pnr-01`)
+**Attribute requirements**: 
+
+- ELN-AP-Pnr-01 (`http://id.elegnamnden.se/ap/1.0/pnr-01`) 
+
 > Natural Personal Identity with Civic Registration Number (personnummer)
+
+* `dateOfBirth`-attribute (`urn:oid:1.3.6.1.5.5.7.9.1`).
 
 <a name="definitions-for-service-property-categories"></a>
 ## 3. Definitions for Service Property Categories
@@ -433,6 +440,7 @@ All Service Type identifiers are prefixed with
 **Changes between version 1.5 and version 1.6:**
 
 - The Service Property Category "scal2" was added to section 3.2.
+- Section 2.5, "eidas-pnr-delivery", was updated to also require attribute release of the `dateOfBirth`-attribute.
 
 **Changes between version 1.4 and version 1.5:**
 

--- a/ELN-0606 - Entity Categories for the Swedish eID Framework.md
+++ b/ELN-0606 - Entity Categories for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Entity Categories for the Swedish eID Framework
 
-### Version 1.6 - 2018-03-18 - *draft version*
+### Version 1.6 - 2018-03-26 - *draft version*
 
 *ELN-0606-v1.6*
 
@@ -295,7 +295,7 @@ have an agreement with the Identity Provider.
 
 **Description**: For asserting a Swedish identity to a foreign service provider via the Swedish eIDAS Proxy Service. This entity category MUST NOT be set by any entity other than Identity Provider providing identity assertions to the Swedish eIDAS Proxy Service and by the Swedish eIDAS Proxy Service itself.
 
-The attribute release is according to the "Natural Personal Identity with Civic Registration Number" attribute set with the addition of the `dateOfBirth`-attribute (`urn:oid:1.3.6.1.5.5.7.9.1`). The reason that the `dateOfBirth`-attribute is required is that the eIDAS minimum dataset requires the birth date, and if an Identity Provider releases a "samordningsnummer" in the `personalIdentityNumber` (instead of a Swedish "personnummer"), the birth date may not be known to the attribute consumer.
+Attribute release is based on the "Natural Personal Identity with Civic Registration Number" attribute set with the addition of a mandatory `dateOfBirth`-attribute (`urn:oid:1.3.6.1.5.5.7.9.1`). The reason for the mandatory `dateOfBirth`-attribute is that this information is required by the eIDAS minimum dataset and therefore must be obtained by the receiving eIDAS Proxy Service. Date of birth can not always reliably be derived from the `personalIdentityNumber` attribute, in particular when this attribute contains a "samordningsnummer".
 
 It is the responsibility of the Swedish eIDAS Proxy Service to transform these attributes into eIDAS attributes.
 


### PR DESCRIPTION
When a Swedish “samordningsnummer” (instead of a “personnummer”) is
delivered it may not be possible for the attribute consumer to deduce
the date of birth. This information is required when delivering
assertion within eIDAS.