### PR TITLE
IS-55 Notes about discovery

### DIFF
--- a/ELN-0600 - Tekniskt ramverk - Svensk e-legitimation.md
+++ b/ELN-0600 - Tekniskt ramverk - Svensk e-legitimation.md
@@ -2,7 +2,7 @@
 
 # E-legitimationsnämndens Tekniska ramverk
 
-### Version: 1.5 - 2017-03-28
+### Version 1.6 - 2018-03-28 - *utkast*
 
 *ELN-0600-v1.5*
 
@@ -37,8 +37,6 @@
 2. [**Tekniska specifikationer**](#tekniska-specifikationer)
 
     2.1. [SAML-profiler](#saml-profiler)
-
-    2.1.1. [Specifikationer för anvisning (Discovery)](#specifikationer-foer-anvisning-(discovery))
 
     2.2. [Specifikationer för identitetsfederationer som följer E-legitimationsnämndens tekniska ramverk](#specifikationer-foer-identitetsfederationer-som-foeljer-e-legitimationsnaemndens-tekniska-ramverk)
 
@@ -435,18 +433,6 @@ kring följande SAML-profiler:
     ”SAML2int profile – SAML 2.0 Interoperability Profile”
     \[[SAML2Int](http://saml2int.org/profile/current/)\].
 
-<a name="specifikationer-foer-anvisning-(discovery)"></a>
-#### 2.1.1. Specifikationer för anvisning (Discovery)
-
-Den specifikation, \[EidDiscovery\], som gällt i tidigare versioner av
-tekniskt ramverk är inte längre korrekt på grund av förändrade
-förutsättningar. Specifikt beror detta på att den tidigare definitionen
-att en e-legitimationsutfärdare endast kunde representeras med en
-legitimeringstjänst inte längre gäller.
-
-E-legitimationsnämnden planerar att utkomma med en uppdaterad
-specifikation rörande anvisning i kommande utkast av tekniskt ramverk.
-
 <a name="specifikationer-foer-identitetsfederationer-som-foeljer-e-legitimationsnaemndens-tekniska-ramverk"></a>
 ### 2.2. Specifikationer för identitetsfederationer som följer E-legitimationsnämndens tekniska ramverk
 
@@ -542,9 +528,6 @@ Context Certificate Extension \[AuthContext\], vilken beskriver hur
 **\[EidEntCat\]**
 > [Entity Categories for the Swedish eID Framework](http://elegnamnden.github.io/technical-framework/latest/ELN-0606_-_Entity_Categories_for_the_Swedish_eID_Framework.html).
 
-**\[EidDiscovery\]**
-> Discovery within the Swedish eID Framework. (Ej längre giltigt).
-
 **\[EidDSSProfile\]**
 > [Implementation Profile for Using OASIS DSS in Central Signing
 > Services](http://elegnamnden.github.io/technical-framework/latest/ELN-0607_-_Implementation_Profile_for_using_DSS_in_Central_Signing_Services.html).
@@ -582,6 +565,10 @@ Context Certificate Extension \[AuthContext\], vilken beskriver hur
 
 <a name="aendringar-mellan-versioner"></a>
 ## 4. Ändringar mellan versioner
+
+**Ändringar mellan version 1.5 och version 1.6:**
+
+- Borttag av underkapitel rörande anvisning.
 
 **Ändringar mellan version 1.4 och version 1.5:**
 

--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Deployment Profile for the Swedish eID Framework
 
-### Version 1.5 - 2018-03-26 - *draft version*
+### Version 1.5 - 2018-03-28 - *draft version*
 
 *ELN-0602-v1.5*
 
@@ -163,6 +163,10 @@ the following syntax is used:
 -   `<mdattr:Element>` – for elements defined in
     \[[SAML2MetaAttr](http://docs.oasis-open.org/security/saml/Post2.0/sstc-metadata-attr.html)\].
 
+When referring to elements from the "Identity Provider Discovery Service Protocol and Profile" specification \[[IdpDisco](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-idp-discovery.pdf)\], the following syntax is used:
+
+- `<idpdisc:DiscoveryResponse>`
+
 When referring to elements from the W3C XML Signature namespace
 (`http://www.w3.org/2000/09/xmldsig\#`) the following syntax is used:
 
@@ -290,6 +294,8 @@ Note that the response message that carries the assertion will always be
 signed, so the Service Provider should only require signed assertions in
 case that it wants to preserve the proof of authenticity of an assertion
 separate from the response.
+
+A Service Provider wishing to make use of a central discovery service as specified in the "Identity Provider Discovery Service Protocol Profile" \[IdPDisco\] MUST include at least one `<idpdisc:DiscoveryResponse>` element as an extension under the `<md:SPSSODescriptor>` element. 
 
 <a name="identity-providers"></a>
 #### 2.1.3. Identity Providers
@@ -430,10 +436,13 @@ section [6.2.1](#attribute-release-rules), “[Attribute Release Rules](#attribu
 <a name="discovery"></a>
 ### 5.1. Discovery
 
-Currently, this deployment profile does not impose any requirements of
+This profile does not impose any requirements of
 how the process of discovery is implemented by Service Providers wishing
 to display user interfaces for selection of Identity Providers for end
-users.
+users. However, Service Providers making use of a centralized
+discovery service as defined in \[IdpDisco\] MUST follow the requirements
+stated for discovery responses in 
+section [2.1.2](##service-providers), "[Service Providers](##service-providers)".
 
 <a name="binding-and-security-requirements"></a>
 ### 5.2. Binding and Security Requirements
@@ -1289,6 +1298,7 @@ response with the status code
 - Section 6.3.4, "The Authentication Statement", contained a requirement about how to process a received authentication context URI that was incorrect. This has been corrected.
 - A new section, 7.2.2, "Requesting SCAL2 Signature Activation Data", was added. This amendment describes how and when to request Signature Activation Data from an Identity Provider in order to enable a signature service to operate as a Qualified Signature Creation Device (QSCD).
 - Attribute release rules have been clarified in sections 2.1.2, "Service Providers" and 6.2.1, "Attribute Release Rules".
+- Section 2.1.2, "Service Providers", was updated to include a requirement for Service Providers communicating with a centralized discovery service.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/ELN-0606 - Entity Categories for the Swedish eID Framework.md
+++ b/ELN-0606 - Entity Categories for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Entity Categories for the Swedish eID Framework
 
-### Version 1.6 - 2018-03-26 - *draft version*
+### Version 1.6 - 2018-03-28 - *draft version*
 
 *ELN-0606-v1.6*
 
@@ -343,9 +343,6 @@ Discovery](#use-in-discovery-services)”. This means that a consuming service m
 mobile-auth category in its metadata in order to have the discovery
 process especially displaying Identity Providers that offer
 authentication using mobile devices.
-
-See \[EidDiscovery\] for a more extensive explanation of the use of the
-mobile-auth category.
 
 <a name="scal2"></a>
 ### 3.2. scal2


### PR DESCRIPTION
Added general requirement about how a SP wishing to make use of a
centralized discovery service according to IdpDisco should indicate
allowed response URLs.
Also cleaned up older text about discovery.