### PR TITLE
IS-57 Proxy IdP:s should support Scoping

### DIFF
--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -505,12 +505,11 @@ user agent to deliver the request. This is useful to prevent malicious
 forwarding of signed requests from being accepted by unintended Identity
 Providers.
 
-A Service Provider SHOULD explicitly specify one requested
+A Service Provider SHOULD explicitly specify a requested
 authentication context element (`<saml2p:RequestedAuthnContext>`),
-containing one or more `<saml2:AuthnContextClassRef>` elements that
-each contains an authentication context URI representing a defined
-Level of Assurance under which the authentication process should be
-performed (see section 3.1.1 of \[EidRegistry\].).
+containing `<saml2:AuthnContextClassRef>` elements each holding
+a Level of Assurance authentication context URI (see section 3.1.1 of \[EidRegistry\]) 
+that the Service Provider considers acceptable for the authentication process.
 
 A present `<saml2p:RequestedAuthnContext>` element MUST specify
 exact matching by means of either an absent `Comparison` attribute or a
@@ -571,18 +570,19 @@ An Identity Provider that acts as a proxy for other Identity Providers SHOULD su
 ```
 *Example of how an `AuthnRequest` contains a `Scoping`-element where the requester signals to the Proxy IdP which Identity Provider that should perform the authentication of the user.*
 
-The Swedish eIDAS Connector is a Proxy IdP proxying requests to foreign eIDAS Proxy Services. Normally, the eIDAS connector presents a country selection dialogue to the user, prompting for the country where the user should be directed to for authentication. However, a Service Provider MAY include a country code URI under the `<saml2p:Scoping>` element of the `<saml2p:AuthnRequest>` in order to bypass the country selection dialogue. For these cases, a country code URI represented according to section 3.1.9 of \[EidRegistry\] should be used.
+The Swedish eIDAS Connector is a Proxy IdP that proxies requests to foreign eIDAS Proxy Services. Normally, the eIDAS connector presents a country selection dialogue to the user, prompting for the country where the user should be directed to for authentication. However, a Service Provider MAY include an eIDAS Proxy Service alias URI for a specific country's Proxy Service under the `<saml2p:Scoping>` element of the `<saml2p:AuthnRequest>` in order to bypass the country selection dialogue. See section 3.1.9.1 of \[EidRegistry\].
 
 ```
 <saml2p:Scoping>
   <saml2p:IDPList>
-    <saml2p:IDPEntry ProviderID="http://id.swedenconnect.se/country/no" />
+    <saml2p:IDPEntry ProviderID="http://id.swedenconnect.se/eidas/1.0/proxy-service/no" />
   </saml2p:IDPList>
 </saml2p:Scoping>
 ```
-*Example of how an `AuthnRequest` sent to the eIDAS Connector requests proxying to Norway for authentication.*
+*Example of how an `AuthnRequest` sent to the eIDAS Connector requests that the eIDAS Connector should
+proxy the request to the Norwegian eIDAS Proxy Service for authentication.*
 
-> Note: A Service Provider may list more than one country in the `<saml2p:IDPList>`. The eIDAS Connector will then present a country selection dialogue containing only the indicated countries.
+> **Note**: A Service Provider may list more than one country in the `<saml2p:IDPList>` of a `<saml2p:Scoping>` element. The eIDAS Connector will then present a country selection dialogue containing only the listed countries.
 
 <a name="processing-requirements"></a>
 ### 5.4. Processing Requirements

--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Deployment Profile for the Swedish eID Framework
 
-### Version 1.5 - 2018-03-28 - *draft version*
+### Version 1.5 - 2018-05-08 - *draft version*
 
 *ELN-0602-v1.5*
 
@@ -508,9 +508,9 @@ Providers.
 A Service Provider SHOULD explicitly specify one requested
 authentication context element (`<saml2p:RequestedAuthnContext>`),
 containing one or more `<saml2:AuthnContextClassRef>` elements that
-each contains an authentication context URI<sup>*</sup> representing a defined
+each contains an authentication context URI representing a defined
 Level of Assurance under which the authentication process should be
-performed.
+performed (see section 3.1.1 of \[EidRegistry\].).
 
 A present `<saml2p:RequestedAuthnContext>` element MUST specify
 exact matching by means of either an absent `Comparison` attribute or a
@@ -560,7 +560,29 @@ to avoid accidental SSO.
 
 If the Service Provider has included more than one `<md:AttributeConsumingService>` element in its metadata it is RECOMMENDED that the `<saml2p:AuthnRequest>` message contains the `AttributeConsumingServiceIndex` attribute holding the index of the `<md:AttributeConsumingService>` element that the Identity Provider should consider during attribute release.
 
-> \[*\]: See section 3.1.1 of \[EidRegistry\].
+An Identity Provider that acts as a proxy for other Identity Providers SHOULD support the `<saml2p:Scoping>` element holding one, or more, entries signalling to the Proxy Identity Provider which Identity Provider(s) that may be used to authenticate the user. See section 3.4.1.5 of \[SAML2Core\].
+
+```
+<saml2p:Scoping>
+  <saml2p:IDPList>
+    <saml2p:IDPEntry ProviderID="http://idp.example.com" />
+  </saml2p:IDPList>
+</saml2p:Scoping>
+```
+*Example of how an `AuthnRequest` contains a `Scoping`-element where the requester signals to the Proxy IdP which Identity Provider that should perform the authentication of the user.*
+
+The Swedish eIDAS Connector is a Proxy IdP proxying requests to foreign eIDAS Proxy Services. Normally, the eIDAS connector presents a country selection dialogue to the user, prompting for the country where the user should be directed to for authentication. However, a Service Provider MAY include a country code URI under the `<saml2p:Scoping>` element of the `<saml2p:AuthnRequest>` in order to bypass the country selection dialogue. For these cases, a country code URI represented according to section 3.1.9 of \[EidRegistry\] should be used.
+
+```
+<saml2p:Scoping>
+  <saml2p:IDPList>
+    <saml2p:IDPEntry ProviderID="http://id.swedenconnect.se/country/no" />
+  </saml2p:IDPList>
+</saml2p:Scoping>
+```
+*Example of how an `AuthnRequest` sent to the eIDAS Connector requests proxying to Norway for authentication.*
+
+> Note: A Service Provider may list more than one country in the `<saml2p:IDPList>`. The eIDAS Connector will then present a country selection dialogue containing only the indicated countries.
 
 <a name="processing-requirements"></a>
 ### 5.4. Processing Requirements
@@ -1299,6 +1321,7 @@ response with the status code
 - A new section, 7.2.2, "Requesting SCAL2 Signature Activation Data", was added. This amendment describes how and when to request Signature Activation Data from an Identity Provider in order to enable a signature service to operate as a Qualified Signature Creation Device (QSCD).
 - Attribute release rules have been clarified in sections 2.1.2, "Service Providers" and 6.2.1, "Attribute Release Rules".
 - Section 2.1.2, "Service Providers", was updated to include a requirement for Service Providers communicating with a centralized discovery service.
+- Section 5.3, "Message Content", was updated to describe the use of `<saml2p:IDPEntry>` elements under the `<samp2p:Scoping>` elements for requests sent to Identity Providers acting as proxies for other Identity Providers.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/ELN-0603 - Registry for Identifiers.md
+++ b/ELN-0603 - Registry for Identifiers.md
@@ -2,7 +2,7 @@
 
 # Registry for identifiers assigned by the Swedish e-identification board
 
-### Version 1.5 - 2018-03-06 - *draft version*
+### Version 1.5 - 2018-05-08 - *draft version*
 
 *ELN-0603-v1.5*
 
@@ -43,6 +43,8 @@
     3.1.7. [Sign Response Status Codes](#sign-response-status-codes)
     
     3.1.8. [Name Registration Authorities](#name-registration-authorities)
+    
+    3.1.9. [Country Code Identifiers](#country-code-identifiers)
     
     3.2. [OID Identifiers](#oid-identifiers)
 
@@ -93,11 +95,12 @@ e-identification board is based on the following components:
 ### 2.1. URI Identifiers
 
 All URI identifiers in this registry are of URL type (Uniform Resource
-Locator), assigned under the prefix `http://id.elegnamnden.se`.
+Locator), assigned under the prefixes `http://id.elegnamnden.se` and `http://id.swedenconnect.se`.
 
 These URL identifiers are defined using the following structure:
 
-**`http://id.elegnamnden.se/{category}[/{version}]/{identifier}`**
+* **`http://id.elegnamnden.se/{category}[/{version}]/{identifier}`**, or,
+* **`http://id.swedenconnect.se/{category}[/{version}]/{identifier}`**.
 
 <a name="oid-identifiers"></a>
 ### 2.2. OID Identifiers
@@ -157,6 +160,7 @@ The following category codes are defined:
 | **auth-cont** | Authentication context information schema. |
 | **status** | SAML Protocol status codes. |
 | **sig-status** | Sign response status codes. |
+| **country** | URI identifier representation of country codes. | 
 | **ns** | XML Schema namespaces. |
 
 <a name="authentication-context-uris"></a>
@@ -323,6 +327,15 @@ Some protocols require a URI identifier to uniquely identify the entity responsi
 | :--- | :--- | :--- |
 | `http://id.elegnamnden.se/eln/name-registration-authority` | Identifying the Swedish e-Identification Board as name registration authority, responsible for a particular name space. | **\[CertProf\]** |
 
+<a name="country-code-identifiers"></a>
+#### 3.1.9. Country Code Identifiers
+
+Country codes represented as URI identifiers within the Swedish eID Framework are represented as:  
+
+**`http://id.swedenconnect.se/country/{country-code}`**
+
+where `{country-code}` is the two letter **\[ISO 3166\]** country code in lowercase. 
+
 <a name="oid-identifiers"></a>
 ### 3.2. OID Identifiers
 
@@ -448,6 +461,9 @@ The following OIDs are defined in the ASN.1 declarations in [3.2.1](#asn1-declar
 > repealing Directive 1999/93/EC. Including implementation acts of the
 > regulation and associated technical specifications.
 
+**\[ISO 3166\]**
+> Country Codes - ISO 3166, [https://www.iso.org/iso-3166-country-codes.html](https://www.iso.org/iso-3166-country-codes.html).
+
 <a name="changes-between-versions"></a>
 ## 5. Changes between versions
 
@@ -460,6 +476,8 @@ The following OIDs are defined in the ASN.1 declarations in [3.2.1](#asn1-declar
 - Added Semantics Identifiers section 3.1.8 to define a name registration authority URI necessary to express a provisional ID attribute in an X.509 certificate according to ETSI EN 319 412-1.
 
 - Added Authentication Context URI:s `http://id.elegnamnden.se/loa/1.0/eidas-nf-low` and `http://id.elegnamnden.se/loa/1.0/eidas-nf-low-sigm` to section 3.1.1.
+
+- Added section 3.1.9, "Country Code Identifiers", that describes the format for country code URI identifiers.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/ELN-0603 - Registry for Identifiers.md
+++ b/ELN-0603 - Registry for Identifiers.md
@@ -44,7 +44,9 @@
     
     3.1.8. [Name Registration Authorities](#name-registration-authorities)
     
-    3.1.9. [Country Code Identifiers](#country-code-identifiers)
+    3.1.9. [eIDAS Identifiers](#eidas-identifiers)
+    
+    3.1.9.1. [eIDAS Proxy Service Aliases](#eidas-proxy-service-aliases)
     
     3.2. [OID Identifiers](#oid-identifiers)
 
@@ -160,7 +162,7 @@ The following category codes are defined:
 | **auth-cont** | Authentication context information schema. |
 | **status** | SAML Protocol status codes. |
 | **sig-status** | Sign response status codes. |
-| **country** | URI identifier representation of country codes. | 
+| **eidas** | Identifiers used for integration with the eIDAS Framework. | 
 | **ns** | XML Schema namespaces. |
 
 <a name="authentication-context-uris"></a>
@@ -327,14 +329,21 @@ Some protocols require a URI identifier to uniquely identify the entity responsi
 | :--- | :--- | :--- |
 | `http://id.elegnamnden.se/eln/name-registration-authority` | Identifying the Swedish e-Identification Board as name registration authority, responsible for a particular name space. | **\[CertProf\]** |
 
-<a name="country-code-identifiers"></a>
-#### 3.1.9. Country Code Identifiers
+<a name="eidas-identifiers"></a>
+#### 3.1.9. eIDAS Identifiers
 
-Country codes represented as URI identifiers within the Swedish eID Framework are represented as:  
+This section defines identifiers used within the Swedish eID Framework to integrate with the eIDAS Framework.
 
-**`http://id.swedenconnect.se/country/{country-code}`**
+<a name="eidas-proxy-service-aliases"></a>
+##### 3.1.9.1. eIDAS Proxy Service Aliases
 
-where `{country-code}` is the two letter **\[ISO 3166\]** country code in lowercase. 
+Each country within the eIDAS federation provides an eIDAS Proxy Service that is a Proxy Identity Provider for the authentication services within that specific country. The entityID identifier for an eIDAS Proxy Service in another country is not known to a Swedish Service Provider, but there are cases in which the Swedish Service Provider needs to refer to a specific eIDAS Proxy Service. Therefore, this specification defines an URI identifier format for eIDAS Proxy Service aliases. The format is as follows:
+
+**`http://id.swedenconnect.se/eidas/1.0/proxy-service/{country-code}`**
+
+where `{country-code}` is the country identifier in ISO 3166-1 alpha-2 format (**\[ISO 3166\]**).
+
+> A consumer of an eIDAS Proxy Service alias URI MUST accept the country code part of the URI in both lower and upper case letters.
 
 <a name="oid-identifiers"></a>
 ### 3.2. OID Identifiers
@@ -477,7 +486,7 @@ The following OIDs are defined in the ASN.1 declarations in [3.2.1](#asn1-declar
 
 - Added Authentication Context URI:s `http://id.elegnamnden.se/loa/1.0/eidas-nf-low` and `http://id.elegnamnden.se/loa/1.0/eidas-nf-low-sigm` to section 3.1.1.
 
-- Added section 3.1.9, "Country Code Identifiers", that describes the format for country code URI identifiers.
+- Added section 3.1.9, "eIDAS Identifiers", that describes the format for eIDAS Proxy Service Alias URI identifiers.
 
 **Changes between version 1.3 and version 1.4:**
 


### PR DESCRIPTION
An update was made so that an SP may request authentication by a
particular IdP when sending an AuthnRequest to a Proxy IdP.